### PR TITLE
Feature/311 - MetadataImpl isEmpty Check

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,12 +132,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-email</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>RELEASE</version>
-			<scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
     </dependencies>
 
 	<!-- ====================================================================== -->

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
@@ -23,6 +23,7 @@ import com.adobe.aem.commons.assetshare.components.details.Metadata;
 import com.adobe.aem.commons.assetshare.content.AssetModel;
 import com.adobe.cq.sightly.SightlyWCMMode;
 import com.day.cq.wcm.api.Page;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ValueMap;
@@ -157,9 +158,8 @@ public class MetadataImpl extends AbstractEmptyTextComponent implements Metadata
                 return true;
             } else if (val instanceof String) {
                 return StringUtils.isBlank((String) val);
-            } else if (val instanceof String[]) {
-                String[] vals = (String[]) val;
-                return vals.length == 1 && StringUtils.isBlank(vals[0]);
+            } else if (val instanceof Object[]) {
+                return ArrayUtils.isEmpty((Object[]) val);
             } else {
                 return false;
             }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
+import java.util.Collection;
 import java.util.Locale;
 
 @Model(
@@ -160,6 +161,9 @@ public class MetadataImpl extends AbstractEmptyTextComponent implements Metadata
                 return StringUtils.isBlank((String) val);
             } else if (val instanceof Object[]) {
                 return ArrayUtils.isEmpty((Object[]) val);
+            } else if (val instanceof Collection) {
+                // This is never null due to the first check
+                return ((Collection) val).isEmpty();
             } else {
                 return false;
             }

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
@@ -1,7 +1,7 @@
 /*
  * Asset Share Commons
  *
- * Copyright (C) 2017 Adobe
+ * Copyright (C) 2018 Adobe
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
+++ b/core/src/main/java/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImpl.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -159,6 +160,9 @@ public class MetadataImpl extends AbstractEmptyTextComponent implements Metadata
                 return true;
             } else if (val instanceof String) {
                 return StringUtils.isBlank((String) val);
+            } else if (val instanceof String[]) {
+                return ArrayUtils.isEmpty((String[]) val) ||
+                        !Arrays.stream((String[]) val).filter(StringUtils::isNotBlank).findFirst().isPresent();
             } else if (val instanceof Object[]) {
                 return ArrayUtils.isEmpty((Object[]) val);
             } else if (val instanceof Collection) {

--- a/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
+++ b/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
@@ -1,0 +1,138 @@
+package com.adobe.aem.commons.assetshare.components.details.impl;
+
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetadataImplTest {
+    String COMBINED_PROPERTY_NAME = "test";
+
+    @Mock
+    ValueMap combinedProperties;
+
+    @InjectMocks
+    MetadataImpl metadataImpl;
+
+    @Before
+    public void setUp() throws Exception {
+        metadataImpl  = new MetadataImpl();
+        MockitoAnnotations.initMocks(this);
+    }
+
+    /** Empty Tests **/
+
+    @Test
+    public void isEmpty_EmptyPropertyName() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(" ").when(metadataImpl).getPropertyName();
+        assertTrue(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_NullPropertyName() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(null).when(metadataImpl).getPropertyName();
+        assertTrue(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_NullPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(null);
+
+        assertTrue(metadataImpl.isEmpty());
+    }
+
+
+    @Test
+    public void isEmpty_EmptyPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(" ");
+
+        assertTrue(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_EmptyStringArrayPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new String[]{});
+
+        assertTrue(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_EmptyDateArrayPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new Date[]{});
+
+        assertTrue(metadataImpl.isEmpty());
+    }
+
+    /** Not Empty Tests **/
+
+    @Test
+    public void isEmpty_NonNullStringPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn("Hello world");
+
+        assertFalse(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_NonNullIntPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(100);
+
+        assertFalse(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_NonEmptyStringArrayPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new String[]{ "Hello", "world"});
+
+        assertFalse(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_NonEmptyObjectArrayPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new Object[] { "Hello from", Calendar.getInstance(), 100});
+
+        assertFalse(metadataImpl.isEmpty());
+    }
+}

--- a/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
+++ b/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
@@ -12,9 +12,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -94,6 +92,16 @@ public class MetadataImplTest {
         assertTrue(metadataImpl.isEmpty());
     }
 
+    @Test
+    public void isEmpty_EmptyCollectionPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new ArrayList(){});
+
+        assertTrue(metadataImpl.isEmpty());
+    }
+
     /** Not Empty Tests **/
 
     @Test
@@ -132,6 +140,20 @@ public class MetadataImplTest {
 
         doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
         when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new Object[] { "Hello from", Calendar.getInstance(), 100});
+
+        assertFalse(metadataImpl.isEmpty());
+    }
+
+    @Test
+    public void isEmpty_NonEmptyCollectionPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        List<String> list = new ArrayList();
+        list.add("Hello");
+        list.add("world");
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(list);
 
         assertFalse(metadataImpl.isEmpty());
     }

--- a/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
+++ b/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * Asset Share Commons
+ *
+ * Copyright (C) 2018 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.adobe.aem.commons.assetshare.components.details.impl;
 
 import org.apache.sling.api.resource.ValueMap;
@@ -143,7 +162,7 @@ public class MetadataImplTest {
 
         assertFalse(metadataImpl.isEmpty());
     }
-    
+
     @Test
     public void isEmpty_StringArrayWithMixedEmptyValuesPropertyValue() {
         metadataImpl = spy(metadataImpl);

--- a/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
+++ b/core/src/test/com/adobe/aem/commons/assetshare/components/details/impl/MetadataImplTest.java
@@ -93,6 +93,16 @@ public class MetadataImplTest {
     }
 
     @Test
+    public void isEmpty_StringArrayWithEmptyValuesPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new String[]{ "", "  ", "      "});
+
+        assertTrue(metadataImpl.isEmpty());
+    }
+
+    @Test
     public void isEmpty_EmptyCollectionPropertyValue() {
         metadataImpl = spy(metadataImpl);
 
@@ -130,6 +140,16 @@ public class MetadataImplTest {
 
         doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
         when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new String[]{ "Hello", "world"});
+
+        assertFalse(metadataImpl.isEmpty());
+    }
+    
+    @Test
+    public void isEmpty_StringArrayWithMixedEmptyValuesPropertyValue() {
+        metadataImpl = spy(metadataImpl);
+
+        doReturn(COMBINED_PROPERTY_NAME).when(metadataImpl).getPropertyName();
+        when(combinedProperties.get(COMBINED_PROPERTY_NAME)).thenReturn(new String[]{ "", "  ", "      ", "hello world", " "});
 
         assertFalse(metadataImpl.isEmpty());
     }

--- a/core/src/test/com/adobe/aem/commons/assetshare/util/PredicateUtilTest.java
+++ b/core/src/test/com/adobe/aem/commons/assetshare/util/PredicateUtilTest.java
@@ -1,12 +1,12 @@
 package com.adobe.aem.commons.assetshare.util;
 
 import org.apache.sling.api.resource.ValueMap;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.assertTrue;
 
 class PredicateUtilTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>2.10.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.day.cq.wcm</groupId>
                 <artifactId>cq-wcm-taglib</artifactId>
                 <version>5.6.4</version>


### PR DESCRIPTION
@HitmanInWis ok - I think this should be better. I incorporated a special check for String[] that contain only "blank" values (check the test cases out):

- https://github.com/HS2-SOLUTIONS/asset-share-commons/compare/bugfix/hide-empty-metadata...davidjgonzalez:feature/311?expand=1#diff-b938c8195e9fb2b227a24fb58a740e13R100
- https://github.com/HS2-SOLUTIONS/asset-share-commons/compare/bugfix/hide-empty-metadata...davidjgonzalez:feature/311?expand=1#diff-b938c8195e9fb2b227a24fb58a740e13R152